### PR TITLE
Carthage support: change CFBundlePackageType from APPL -> FMWK

### DIFF
--- a/DominantColor/iOS/Info.plist
+++ b/DominantColor/iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
Problem: [Carthage](https://github.com/Carthage/Carthage) (and any project which includes this) needs the target to be bundled as a framework rather than an application
- Changed `CFBundlePackageType` / 'Bundle OS type code' of iOS Target from `APPL` to `FMWK` (framework) for Carthage support.